### PR TITLE
fix order-constraint bug, add constraint ordering to main

### DIFF
--- a/scheme/order-constraints.sls
+++ b/scheme/order-constraints.sls
@@ -107,10 +107,11 @@
            (map compute-new-defs constraints))))
 
   (define (best-by-violations constraints uncovered)
-    (best-by-score constraints (compute-violations constraints uncovered)))
+    (best-by-score constraints (compute-violations (map cdr constraints)
+                                                   uncovered)))
 
   (define (best-by-costs constraints defines)
-    (best-by-score constraints (compute-costs constraints defines)))
+    (best-by-score constraints (compute-costs (map cdr constraints) defines)))
 
   (define (next-constraint constraints defines cover)
     (list (random-element (best-by-costs (best-by-violations constraints
@@ -140,9 +141,8 @@
       (define best-of-some-covers (choose-best-cover some-covers))
       (define all-covers (make-all-vertex-covers graph))
       (define best-of-all-covers (choose-best-cover all-covers))
-      (define ordering (order-constraints (map cdr constraints)
-                                          '()
-                                          best-of-all-covers))
+      ;; don't use '() in production code, but defines instead
+      (define ordering (order-constraints constraints '() best-of-all-covers))
 
     (displaynerr "\n#### input ############################################\n")
     (map displaynerr all-input)


### PR DESCRIPTION
This code should fix the problem you mentioned via email @piantado.

My previous commits stripped the type of constraints off each constraint, meaning there was no clear relationship (e.g. equality, inequality, recursive equality, ...) between each pair of structures. That's now fixed.

This commit also adds a small chunk of code to main.sls which allows you to configure which type of constraint ordering you'd like to use.
