### PR TITLE
add Dockerfile containerizing vicare scheme

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM debian:latest
+
+# make sure everything's up to date
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get -y update
+
+# install the dev tools
+RUN apt-get install -y apt-utils
+RUN apt-get install -y git libtool autoconf make rlwrap texinfo
+
+# install the libraries vicare scheme needs
+RUN apt-get install -y libffi-dev libgmp-dev libgsl0-dev
+
+# clone and configure vicare scheme
+RUN git clone https://github.com/marcomaggi/vicare.git
+WORKDIR vicare/
+RUN /bin/sh ./autogen.sh
+RUN ./configure --enable-maintainer-mode --enable-sources-installation
+
+# compile and install vicare scheme
+RUN make
+RUN make install
+
+CMD ["/bin/bash"]

--- a/run_vicare.sh
+++ b/run_vicare.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+CHURISO_DIR="<put-churiso-dir-here>"
+
+if [ -f ./vicare-docker ]
+then
+    docker build -t vicare-docker .
+fi
+
+docker run -itv $CHURISO_DIR:/churiso vicare-docker


### PR DESCRIPTION
`vicare` doesn't install nicely on OS X, so the files added here allow OS X users to easily build `vicare` in an lightweight, isolated Linux environment using [Docker](http://docker.com). It works pretty smoothly for me.
